### PR TITLE
fix: steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ rm -r ./smart_city_model
 mv interscsimulator-smart-city-model/ ./smart_city_model
 ```
 
-4. Now, go to the root directory `interscsimulator/` and run the application using the Docker command.
+4. Now, go to the root directory `interscsimulator/` and run the application using the Docker command:
+```bash
+cd ..
+```
 
 5. Build the Docker image:
 ```bash
-cd ..
 docker build -t interscsimulator .
 ```
 6. Run the Docker container:


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file to improve the instructions for running the application using Docker. The change adds a command to navigate to the root directory before building the Docker image.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-L39): Added a `cd ..` command to step 4 to ensure users navigate to the root directory `interscsimulator/` before running the Docker command.